### PR TITLE
Basic 김가희

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <body>
         <div class="navbar">
             <div class="logo">
-                <img src="image/Group_22.png">
+                <img src="image/Group_22.png" class="panda-logo">
                 <a href ="/">
                     <img src="image/logo.svg" class="logotxt" alt='판다마켓 글자'></img>
                 </a>

--- a/index.html
+++ b/index.html
@@ -4,10 +4,7 @@
         <meta charset="UTF-8">
         <title>판다 마켓</title>
         <link rel="stylesheet" href="style.css">
-        <link
-            rel="stylesheet"
-            href="https://cdn.jsdelivr.net/npm/reset-css@4.0.1/reset.min.css"
-        />
+        <link rel="stylesheet" href="reset.css" />
     </head>
     <body>
         <div class="navbar">
@@ -18,13 +15,13 @@
                 </a>
             </div>
             <div>
-                <button class="navbtn txt" onclick="location.href='login.html'">로그인</button>
+                <a class="navbtn txt" href='login.html'>로그인</a>
             </div>
         </div>
         <div class="top-back">
             <div class="txtbtn">
                 <span class="top-text">일상의 모든 물건을 <br> 거래해 보세요</span>
-                <button class="topbtn txt" onclick="location.href='lookaround.html'">구경하러 가기</button>
+                <a class="topbtn txt" href='lookaround.html'>구경하러 가기</a>
             </div>
             <img src="image/Img_home_top.png" class="top-img">
         </div>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
             <div class="logo">
                 <img src="image/Group_22.png">
                 <a href ="/">
-                    <img src="image/logo.svg" class="logotxt"></img>
+                    <img src="image/logo.svg" class="logotxt" alt='판다마켓 글자'></img>
                 </a>
             </div>
             <div>
@@ -54,10 +54,18 @@
                     </span>
                 </div>
                 <span>
-                    <img src="image/facebook.png">
-                    <img src="image/twitter.png">
-                    <img src="image/youtube.png">
-                    <img src="image/instagram.png">
+                    <a href='https://www.facebook.com/?locale=ko_KR' target="_blank">
+                        <img src="image/facebook.png">
+                    </a>
+                    <a href='https://x.com/?lang=ko' target="_blank">
+                        <img src="image/twitter.png">
+                    </a>
+                    <a href="https://www.youtube.com/?hl=ko&gl=KR&app=desktop" target="_blank">
+                        <img src="image/youtube.png">
+                    </a>
+                    <a href="https://www.instagram.com/sem/campaign/emailsignup/?campaign_id=13530338586&extra_1=s%7Cc%7C547419126947%7Ce%7Cinstagram%20c%7C&placement=&creative=547419126947&keyword=instagram%20c&partner_id=googlesem&extra_2=campaignid%3D13530338586%26adgroupid%3D126262419014%26matchtype%3De%26network%3Dg%26source%3Dnotmobile%26search_or_content%3Ds%26device%3Dc%26devicemodel%3D%26adposition%3D%26target%3D%26targetid%3Dkwd-1321618852491%26loc_physical_ms%3D9197620%26loc_interest_ms%3D%26feeditemid%3D%26param1%3D%26param2%3D&gad_source=1&gclid=EAIaIQobChMIzebolvaKiAMV0l4PAh0gcSwWEAAYASAAEgJlLvD_BwE" target="_blank">
+                        <img src="image/instagram.png">
+                    </a>
                 </span>
             </div>
         </footer>

--- a/index.html
+++ b/index.html
@@ -19,11 +19,17 @@
             </div>
         </div>
         <div class="top-back">
-            <div class="txtbtn">
-                <span class="top-text">일상의 모든 물건을 <br> 거래해 보세요</span>
-                <a class="topbtn txt" href='lookaround.html'>구경하러 가기</a>
+            <div class="top-box">
+                <div class="txtbtn">
+                    <div class="txt-align-box">
+                        <span class="top-text">일상의 모든 물건을&nbsp</span> 
+                        <span class="top-text">거래해 보세요</span>
+                    </div>
+                    <a class="topbtn txt" href='lookaround.html'>구경하러 가기</a>
+                </div>
+                
+                <img src="image/Img_home_top.png" class="top-img"></img>
             </div>
-            <img src="image/Img_home_top.png" class="top-img">
         </div>
         <div class="floor-box">
             <img src="image/desktop_02.png" class="secondimg">

--- a/login.css
+++ b/login.css
@@ -1,7 +1,7 @@
 body{
     display: flex;
-    width: 100vw;
-    height: 100vh;
+    width: 100%;
+    height: 100%;
     flex-direction: column;
     justify-content: center;
     align-items: center;
@@ -37,7 +37,6 @@ body{
     border-radius: 12px;
     height: 56px;
     padding-left: 24px;
-    /* gap:10px 이거 있고 없고의 차이가 무엇인가요 ?*/
 }
 
 .input:focus {
@@ -46,7 +45,6 @@ body{
 
 .input::placeholder{
     color: #9CA3AF;
-    font-family: 'Pretendard Variable';
     font-weight: 400;
 }
 
@@ -108,3 +106,6 @@ body{
     font-weight: 500;
 }
 
+@media (min-width: 768px) {
+
+}

--- a/login.html
+++ b/login.html
@@ -27,12 +27,12 @@
     </div>
     <main class="container">
       <form class="email-box">
-        <label class="email-label">이메일</label>
-        <input class="input" placeholder="이메일을 입력해주세요">
+        <label class="email-label" for ="email">이메일</label>
+        <input class="input" placeholder="이메일을 입력해주세요" id="email">
       </form>
       <form class="pw-box">
-        <label class="pw-label">비밀번호</label>
-        <input class="input" placeholder="비밀번호를 입력해주세요" type="password">
+        <label class="pw-label" for ="pw">비밀번호</label>
+        <input class="input" placeholder="비밀번호를 입력해주세요" type="password" id="pw">
       </form>
       <button class="login-btn" onclick="location.href='/login'">로그인</button>
       <article class="easy-login-box">

--- a/reset.css
+++ b/reset.css
@@ -26,6 +26,28 @@ dd {
   margin-block-end: 0;
 }
 
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+/* 출처: https://keembloo.tistory.com/5 [keembloo:티스토리] */
+
 /* list를 role값으로 갖는 ul, ol 요소의 기본 목록 스타일을 제거합니다. */
 ul[role='list'],
 ol[role='list'] {

--- a/reset.css
+++ b/reset.css
@@ -43,7 +43,6 @@ time, mark, audio, video {
 	padding: 0;
 	border: 0;
 	font-size: 100%;
-	font: inherit;
 	vertical-align: baseline;
 }
 /* 출처: https://keembloo.tistory.com/5 [keembloo:티스토리] */

--- a/style.css
+++ b/style.css
@@ -8,11 +8,17 @@ body {
     font-family: 'Pretendard Variable';
 }
 
+span {
+    text-decoration: none;
+}
+
 .txt {
     text-decoration: none;
     color: #F9FAFB;
     font-family: 'Pretendard Variable';
 }
+
+
 
 .navbar {
     display: flex;

--- a/style.css
+++ b/style.css
@@ -3,20 +3,62 @@
 	src: url('Pretendard-Regular.ttf');
 }
 
+
+/* Mobile */
+@media (min-width: 375px) { 
+    .navbar {
+        padding-left: 16px;
+        padding-right: 16px;
+    }
+
+    .panda-logo {
+        display: none;
+    }
+
+    .top-back {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .txtbtn {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+}
+
+/* Tablet */
+@media (min-width:768px) { 
+    .navbar {
+        padding-left: 24px;
+        padding-right: 24px;
+    }
+
+    .panda-logo {
+        display: inline-block;
+    }
+
+    
+}
+
+/* Desktop */
+@media (min-width:1200px) { 
+    .navbar {
+        padding-left: 400px;
+        padding-right: 400px;
+    }
+}
+
 body {
     width: 100%;
     font-family: 'Pretendard Variable';
+    white-space: nowrap;
 }
-
-
 
 .txt {
     text-decoration: none;
     color: #F9FAFB;
-    font-family: 'Pretendard Variable';
 }
-
-
 
 .navbar {
     display: flex;
@@ -25,8 +67,6 @@ body {
     height: 70px;
     border: 1px;
     gap: 10px;
-    padding-left: 400px;
-    padding-right: 400px;
     position: sticky; 
     top:0;
     left:0;
@@ -39,7 +79,7 @@ body {
     font-size: 16px;
     font-weight: 600;
     Line-height: 26px;
-    width: 128px;
+    /* width: 128px; */
     height: 48px;
     padding: 12px 23px 12px 23px;
     gap: 10px;
@@ -140,7 +180,7 @@ body {
 
 .floor-box {
     height: 720px;
-    width: 1920px;
+    width: 100%;
 }
 
 .secondimg,
@@ -151,12 +191,10 @@ body {
 
 .secondimg {
     margin: 138px 605px 138px 360px;
-    width: 955px;
 }
 
 .thirdimg {
-    margin: 138px 360px 138px 591px;
-    width: 969px;
+    margin: 138px 50% 138px 50%;
 }
 
 .fourthimg {
@@ -170,8 +208,8 @@ body {
     color: #E5E7EB;
 }
 
-.distan {
-    margin-right: 30px;
+.active-txt {
+    gap: 30px;
 }
 
 .foot-txt {
@@ -179,3 +217,17 @@ body {
     display: flex;
     justify-content: space-around;
 }
+
+
+
+.active-txt,
+.foot-txt > span {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+span {
+    gap: 12px
+}
+

--- a/style.css
+++ b/style.css
@@ -8,9 +8,7 @@ body {
     font-family: 'Pretendard Variable';
 }
 
-span {
-    text-decoration: none;
-}
+
 
 .txt {
     text-decoration: none;
@@ -56,8 +54,6 @@ span {
     font-size: 20px;
     font-weight: 600;
     text-align: center;
-    width: 357px;
-    height: 56px;
     padding: 16px 124px 16px 124px;
     gap: 10px;
     border: 1px;

--- a/style.css
+++ b/style.css
@@ -18,13 +18,18 @@
     .top-back {
         display: flex;
         flex-direction: column;
+        justify-content: center;
+        align-items: center;
     }
+
 
     .txtbtn {
         display: flex;
         flex-direction: column;
         align-items: center;
+        margin-top:48px;
     }
+
 }
 
 /* Tablet */
@@ -37,8 +42,43 @@
     .panda-logo {
         display: inline-block;
     }
+    .top-text {
+        text-align: left;
+    }
 
+    .txtbtn {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        margin-top:84px;
+    }
+
+    .txt-align-box {
+        display: flex;
+        flex-direction: row;
+    }
+    .secondimg {
+        margin: 0;
+    }
     
+    .thirdimg {
+        margin: 0;
+    }
+    
+    .fourthimg {
+        margin: 0;
+        width: 987px;
+    }
+    .top-text,
+    .bottom-text {
+        font-weight: 700;
+        font-size: 40px;
+        line-height: 56px;
+        color: #374151;
+        /* display: flex;
+        justify-content: flex-start;
+        align-items: center; */
+    }
 }
 
 /* Desktop */
@@ -46,6 +86,48 @@
     .navbar {
         padding-left: 400px;
         padding-right: 400px;
+    }
+
+    .top-box {
+        display: flex;
+        margin-top:200px;
+
+    }
+
+    .txtbtn {
+        display: flex;
+        justify-content: center;
+        margin-top: 40px;
+    }
+    .top-back {
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        align-items: center;
+    }
+
+    .txt-align-box {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .top-img {
+        width: 746px;
+        height: 340px;
+        display: flex;
+        justify-content: center;
+    }
+    .secondimg {
+        margin: 138px 605px 138px 360px;
+    }
+    
+    .thirdimg {
+        margin: 138px 50% 138px 50%;
+    }
+    
+    .fourthimg {
+        margin: 138px 573px 138px 360px;
+        width: 987px;
     }
 }
 
@@ -106,9 +188,7 @@ body {
 }
 
 
-.txtbtn {
-    margin: 240px 7px 40px 0;
-}
+
 
 .navbtn:active {
     background-color: #1251AA;
@@ -145,28 +225,15 @@ body {
     align-items: center;
 }
 
-.top-img {
-    width: 746px;
-    height: 340px;
-    display: flex;
-    justify-content: flex-end;
-    margin-left: 69px;
-}
 
 
 
 .top-back {
     background-color: #CFE5FF;
-    width: 100%;
-    height: 540px;
-    display: flex;
-    justify-content: center;
-    align-items: flex-end;
 }
 
 .bottom-back {
     background-color: #CFE5FF;
-    width: 1920px;
     height: 540px;
     display: flex;
     justify-content: center;
@@ -180,7 +247,9 @@ body {
 
 .floor-box {
     height: 720px;
-    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 .secondimg,
@@ -189,18 +258,7 @@ body {
     height: 444px;
 }
 
-.secondimg {
-    margin: 138px 605px 138px 360px;
-}
 
-.thirdimg {
-    margin: 138px 50% 138px 50%;
-}
-
-.fourthimg {
-    margin: 138px 573px 138px 360px;
-    width: 987px;
-}
 
 .foot {
     height: 160px;


### PR DESCRIPTION
## **체크리스트 [기본]**

**공통**

- [x]  브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
    - PC: `1200px` 이상
    - Tablet: `768px` 이상 ~ `1199px` 이하 / 24px
    - Mobile: `375px` 이상 ~ `767px` 이하
    - `375px` 미만 사이즈의 디자인은 고려하지 않습니다

**랜딩 페이지**

- [x]  Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 `24px`, “로그인” 버튼 오른쪽 여백 `24px`을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x]  Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 `16px`, “로그인” 버튼 오른쪽 여백 `16px`을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x]  화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.

**로그인, 회원가입 페이지 공통**

- [ ]  Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [ ]  Mobile 사이즈에서 좌우 여백 `16px` 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [ ]  Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 `400px`을 넘지 않습니다.

## **체크리스트 [심화]**

- [ ]  페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [ ]  미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
- [ ]  주소와 이미지는 자유롭게 설정하세요.
## 주요 변경사항

-
-

## 스크린샷

![image](이미지url)

## 멘토에게

-
-
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
