### PR TITLE
[김가희] sprint4

### DIFF
--- a/login.css
+++ b/login.css
@@ -43,6 +43,22 @@ body{
     outline-color: #3692FF;;
 }
 
+.error {
+    border:1px solid red;
+}
+
+.error-message-pw {
+    outline-color: red;
+    color: red;
+    display: none;
+}
+
+.error-message {
+    outline-color: red;
+    color: red;
+    display: none;
+}
+
 .input::placeholder{
     color: #9CA3AF;
     font-weight: 400;

--- a/login.css
+++ b/login.css
@@ -47,13 +47,11 @@ body{
     border:1px solid red;
 }
 
-.error-message-pw {
-    outline-color: red;
-    color: red;
-    display: none;
-}
 
-.error-message {
+.error-message,
+.error-message-pw,
+.error-message-nick,
+.error-message-pwcheck {
     outline-color: red;
     color: red;
     display: none;

--- a/login.html
+++ b/login.html
@@ -29,12 +29,14 @@
       <form class="email-box">
         <label class="email-label" for ="email">이메일</label>
         <input class="input" placeholder="이메일을 입력해주세요" id="email">
+        <div class="error-message"></div>
       </form>
       <form class="pw-box">
         <label class="pw-label" for ="pw">비밀번호</label>
         <input class="input" placeholder="비밀번호를 입력해주세요" type="password" id="pw">
+        <div class='error-message-pw'></div>
       </form>
-      <button class="login-btn" onclick="location.href='/login'">로그인</button>
+      <button id="login" class="login-btn" onclick="location.href='/items'">로그인</button>
       <article class="easy-login-box">
         <div class="easy-content">
           <span>간편 로그인하기</span>
@@ -49,5 +51,6 @@
         <a href="signup.html">회원가입</a>
       </section>
     </main>
+    <script src="login.js"></script>
   </body>
 </html>

--- a/login.js
+++ b/login.js
@@ -20,8 +20,6 @@ function emailForm(e) {
 }
 
 function pwForm(e) {
-  console.log("focus out 발생")
-  // 이메일 input이 비어있음
   if (pwInputElement.value === '') {
     pwInputElement.classList.add('error');
     pwErrorMessage.textContent ="비밀번호를 입력해주세요."

--- a/login.js
+++ b/login.js
@@ -4,8 +4,6 @@ const errorMessage = document.querySelector('.error-message');
 const pwErrorMessage = document.querySelector('.error-message-pw');
 
 function emailForm(e) {
-  console.log("focus out 발생")
-  // 이메일 input이 비어있음
   if (emailInputElement.value === '') {
     emailInputElement.classList.add('error');
     errorMessage.textContent ="이메일을 입력해주세요."
@@ -60,15 +58,11 @@ const loginElement = document.querySelector("#login")
 function activateLogin(e){
   if(emailInputElement.classList.contains('error') 
     || pwInputElement.classList.contains('error')){
-      //드모르간 극혐
-      //deactivate
       loginElement.style.backgroundColor = "#9CA3AF"
       
   } else if(emailInputElement.value === '' || pwInputElement.value === ''){
-      //deactivate
       loginElement.style.backgroundColor = "#9CA3AF"
   }else{
-    //activate
       loginElement.style.backgroundColor = "#3692FF"
   }
 }
@@ -78,5 +72,3 @@ emailInputElement.addEventListener('blur', activateLogin)
 
 
 
-// 로그인 버튼을 활성화시키는 함수 
-//  ( if-else 써서, 둘다 충족이 되는거면 로그인 버튼 활성화,아니면? 비활성화)

--- a/login.js
+++ b/login.js
@@ -1,0 +1,82 @@
+const emailInputElement = document.querySelector('#email');
+const pwInputElement = document.querySelector('#pw');
+const errorMessage = document.querySelector('.error-message');
+const pwErrorMessage = document.querySelector('.error-message-pw');
+
+function emailForm(e) {
+  console.log("focus out 발생")
+  // 이메일 input이 비어있음
+  if (emailInputElement.value === '') {
+    emailInputElement.classList.add('error');
+    errorMessage.textContent ="이메일을 입력해주세요."
+    errorMessage.style.display = 'block';
+  } else if (!(emailInputElement.value.includes("@")
+  && emailInputElement.value.includes("."))) {
+    emailInputElement.classList.add('error');
+    errorMessage.textContent ="잘못된 이메일 형식입니다."
+    errorMessage.style.display = 'block';
+  }else{
+    emailInputElement.classList.remove('error');
+    errorMessage.style.display = 'none';
+  }
+}
+
+function pwForm(e) {
+  console.log("focus out 발생")
+  // 이메일 input이 비어있음
+  if (pwInputElement.value === '') {
+    pwInputElement.classList.add('error');
+    pwErrorMessage.textContent ="비밀번호를 입력해주세요."
+    pwErrorMessage.style.display = 'block';
+  } else if (pwInputElement.value.length < 8) {
+    pwInputElement.classList.add('error');
+    pwErrorMessage.textContent ="비밀번호를 8자 이상 입력해주세요."
+    pwErrorMessage.style.display = 'block';
+  }else{
+    pwInputElement.classList.remove('error');
+    pwErrorMessage.style.display = 'none';
+  }
+}
+
+function removeMessage(e){
+  if(e.target.id === "email"){
+    errorMessage.style.display = 'none';  
+  }else{
+    pwErrorMessage.style.display = 'none';
+  }
+}
+
+
+emailInputElement.addEventListener('blur', emailForm)
+emailInputElement.addEventListener('focus', removeMessage)
+
+pwInputElement.addEventListener('blur', pwForm)
+pwInputElement.addEventListener('focus', removeMessage)
+
+// ----------------------------------------------------------
+
+const loginElement = document.querySelector("#login")
+
+function activateLogin(e){
+  if(emailInputElement.classList.contains('error') 
+    || pwInputElement.classList.contains('error')){
+      //드모르간 극혐
+      //deactivate
+      loginElement.style.backgroundColor = "#9CA3AF"
+      
+  } else if(emailInputElement.value === '' || pwInputElement.value === ''){
+      //deactivate
+      loginElement.style.backgroundColor = "#9CA3AF"
+  }else{
+    //activate
+      loginElement.style.backgroundColor = "#3692FF"
+  }
+}
+
+pwInputElement.addEventListener('blur', activateLogin)
+emailInputElement.addEventListener('blur', activateLogin)
+
+
+
+// 로그인 버튼을 활성화시키는 함수 
+//  ( if-else 써서, 둘다 충족이 되는거면 로그인 버튼 활성화,아니면? 비활성화)

--- a/signup.html
+++ b/signup.html
@@ -28,21 +28,25 @@
     <main class="container">
       <form class="email-box">
         <label class="email-label">이메일</label>
-        <input class="input" placeholder="이메일을 입력해주세요">
+        <input class="input" id="email" placeholder="이메일을 입력해주세요">
+        <div class="error-message"></div>
       </form>
       <form class="nickname-box">
         <label class="nickname-label">닉네임</label>
-        <input class="input" placeholder="닉네임을 입력해주세요">
+        <input class="input" id="nickname" placeholder="닉네임을 입력해주세요">
+        <div class="error-message-nick"></div>
       </form>
       <form class="pw-box">
         <label class="pw-label">비밀번호</label>
-        <input class="input" placeholder="비밀번호를 입력해주세요"  type="password">
+        <input class="input" id="pw" placeholder="비밀번호를 입력해주세요"  type="password">
+        <div class="error-message-pw"></div>
       </form>
       <form class="pw-repeat-box">
         <label class="pw-repeat-label">비밀번호 확인</label>
-        <input class="input" placeholder="비밀번호를 다시 한 번 입력해주세요"  type="password">
+        <input class="input" id="pwcheck" placeholder="비밀번호를 다시 한 번 입력해주세요"  type="password">
+        <div class="error-message-pwcheck"></div>
       </form>
-      <button class="login-btn" onclick="location.href='/login'">회원가입</button>
+      <button class="login-btn">회원가입</button>
       <article class="easy-login-box">
         <div class="easy-content">
           <span>간편 로그인하기</span>
@@ -57,5 +61,6 @@
         <a href="login.html">로그인</a>
       </section>
     </main>
+  <script src="signup.js"></script>
   </body>
 </html>

--- a/signup.js
+++ b/signup.js
@@ -1,0 +1,131 @@
+let signupValid = false
+
+//ID 선택하기
+const emailInputElement = document.getElementById('email');
+const nickInputElement = document.getElementById('nickname');
+const pwInputElement = document.getElementById('pw');
+const pwCheckInputElement = document.getElementById('pwcheck');
+const errorMessage = document.querySelector('.error-message');
+const nickErrorMessage = document.querySelector('.error-message-nick');
+const pwErrorMessage = document.querySelector('.error-message-pw');
+const pwCheckErrorMessage = document.querySelector('.error-message-pwcheck');
+const signupElement = document.querySelector('.login-btn')
+
+
+
+
+
+function emailForm(e) {
+  if (emailInputElement.value === '') {
+    emailInputElement.classList.add('error');
+    errorMessage.textContent = "이메일을 입력해주세요"
+    errorMessage.style.display = 'block';
+  } else if (!(emailInputElement.value.includes("@")
+  && emailInputElement.value.includes("."))) {
+    emailInputElement.classList.add('error');
+    errorMessage.textContent ="잘못된 이메일 형식입니다."
+    errorMessage.style.display = 'block';
+  }else{
+    emailInputElement.classList.remove('error');
+    errorMessage.style.display = 'none';
+  };
+};
+
+function nickForm(e) {
+  if (nickInputElement.value === '') {
+    nickInputElement.classList.add('error');
+    nickErrorMessage.textContent = "닉네임을 입력해주세요."
+    nickErrorMessage.style.display = "block";
+  } else {
+    nickInputElement.classList.remove('error');
+    nickErrorMessage.style.display = 'none';
+  };
+};
+
+function pwForm(e) {
+  if (pwInputElement.value === '') {
+    pwInputElement.classList.add('error');
+    pwErrorMessage.textContent ="비밀번호를 입력해주세요."
+    pwErrorMessage.style.display = 'block';
+  } else if (pwInputElement.value.length < 8) {
+    pwInputElement.classList.add('error');
+    pwErrorMessage.textContent ="비밀번호를 8자 이상 입력해주세요."
+    pwErrorMessage.style.display = 'block';
+  }else{
+    pwInputElement.classList.remove('error');
+    pwErrorMessage.style.display = 'none';
+  };
+};
+
+function removeMessage(e){
+  if(e.target.id === "email"){
+    errorMessage.style.display = 'none';  
+  } else if(e.target.id === "nickname"){
+    nickErrorMessage.style.display = 'none';
+  } else if(e.target.id === "pw"){
+    pwErrorMessage.style.display = 'none';
+  } else{
+    pwCheckErrorMessage.style.display = 'none';
+  };
+};
+
+function pwValid(e) {
+  if (!(pwInputElement.value === pwCheckInputElement.value)) {
+    pwCheckInputElement.classList.add('error');
+    pwCheckErrorMessage.textContent = "비밀번호가 일치하지 않습니다.."
+    pwCheckErrorMessage.style.display = 'block';
+  }else{
+    pwCheckInputElement.classList.remove('error');
+    pwCheckErrorMessage.style.display = 'none';
+  };
+}
+
+function activateSignup(e){
+  if(
+    emailInputElement.classList.contains('error') 
+    || nickInputElement.classList.contains('error')
+    || pwInputElement.classList.contains('error')
+    || pwCheckInputElement.classList.contains('error')
+  ) {
+    signupElement.style.backgroundColor = "#9CA3AF"
+  } else if (
+    emailInputElement.value ==='' 
+    || nickInputElement.value ===''
+    || pwInputElement.value ===''
+    || pwCheckInputElement.value === ''
+  ) {
+    signupElement.style.backgroundColor = "#9CA3AF"
+  } else {
+    signupElement.style.backgroundColor = "#3692FF"
+    signupValid = true
+  }
+}
+
+
+
+emailInputElement.addEventListener('blur', emailForm);
+nickInputElement.addEventListener('blur', nickForm);
+pwInputElement.addEventListener('blur', pwForm);
+pwCheckInputElement.addEventListener('blur', pwValid);
+
+emailInputElement.addEventListener('focus',removeMessage)
+nickInputElement.addEventListener('focus',removeMessage)
+pwInputElement.addEventListener('focus',removeMessage)
+pwCheckInputElement.addEventListener('focus',removeMessage)
+
+
+emailInputElement.addEventListener('blur', activateSignup)
+nickInputElement.addEventListener('blur', activateSignup)
+pwInputElement.addEventListener('blur', activateSignup)
+pwCheckInputElement.addEventListener('blur', activateSignup)
+
+pwInputElement.addEventListener('change',pwValid);
+
+
+function signupButton(e){
+  if(signupValid){
+    window.location.href = "/login.html"
+  }
+}
+
+signupElement.addEventListener("click",signupButton)

--- a/signup.js
+++ b/signup.js
@@ -124,7 +124,7 @@ pwInputElement.addEventListener('change',pwValid);
 
 function signupButton(e){
   if(signupValid){
-    window.location.href = "/login.html"
+    window.location.href = "/login"
   }
 }
 


### PR DESCRIPTION
## 요구사항
- Github에 PR(Pull Request)을 만들어서 미션을 제출합니다.
- 피그마 디자인에 맞게 페이지를 만들어 주세요.
- React와 같은 UI 라이브러리를 사용하지 않고 진행합니다.
### 기본
- 로그인

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘로그인’ 버튼은 비활성화 됩니다.
- [x] input 에 유효한 값을 입력하면 ‘로그인' 버튼이 활성화 됩니다.
- [x] 활성화된 ‘로그인’ 버튼을 누르면 “/items” 로 이동합니다
-회원가입

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 “잘못된 이메일 형식입니다” 빨강색 에러 메세지를 보입니다.
- [x] 닉네임 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “닉네임을 입력해주세요.” 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지를 보입니다
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 “비밀번호를 8자 이상 입력해주세요.” 에러 메세지를 보입니다.
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input 아래에 “비밀번호가 일치하지 않습니다..” 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 ‘회원가입’ 버튼은 비활성화 됩니다.
- [x] input 에 유효한 값을 입력하면 ‘회원가입' 버튼이 활성화 됩니다.
- [x] 활성화된 ‘회원가입’ 버튼을 누르면 “/signup” 로 이동합니다


### 심화
- [ ] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 합니다.
- [ ] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이도록 합니다.



## 주요 변경사항

- 
-

## 스크린샷

![image](이미지url)

## 멘토에게
- 코드를 짤 때 비슷한 로직들이 많아서 더 깔끔하게 만드는 방법이 있는지 궁금합니다!
- signup.js에서 사이트 이동하는 방법은 구글링을 통해 해결하였습니다 아래는 참조한 블로그 링크입니다!
- https://shanepark.tistory.com/206
- https://beamish-taiyaki-37d19f.netlify.app/ netlify 배포 사이트 첨부 합니다!
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
